### PR TITLE
Update analyse script to provide the repo object

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,14 @@ the rules or not.
 ## Usage
 
 * `bundle install`
-* [Create a Github OAuth token](https://github.com/settings/tokens/new)
+* [Create a Github OAuth token](https://github.com/settings/tokens/new) with at least the following scopes enabled: _read:org, read:repo_hook, read:user, repo:status_
 * `export GH_TOKEN=[your OAuth token]`
+
+To analyse all repositories in the ministryofjustice organisation:
 * `bin/analyse.rb`
+
+To analyse a specific repository:
+* `bin/check-repo.rb [username] [repository name]`
 
 # TODO
 

--- a/bin/analyse.rb
+++ b/bin/analyse.rb
@@ -8,6 +8,6 @@ github = Github.new(auto_pagination: false, oauth_token: ENV.fetch('GH_TOKEN'))
 
 # Just check a few repos, for speed
 github.repos.list(user: 'ministryofjustice')[10..15].map do |repo|
-  ap RepoAudit::Report.new(repo).run
+  ap RepoAudit::Report.new(repo: repo).run
   puts
 end


### PR DESCRIPTION
The `analyse.rb` script was broken by changes to the report
class which were not back-ported. This commit fixes that.

Also, the README has been updated to document the two scripts
and the necessary token scopes.