### PR TITLE
Transform the bin/analyse.rb output to CSV

### DIFF
--- a/bin/analyse.rb
+++ b/bin/analyse.rb
@@ -3,7 +3,8 @@
 require_relative '../lib/repo-audit'
 
 # Just check a few repos, for speed
-RepoAudit::RepositoryHelper.list(user: 'ministryofjustice')[10..15].each do |repo|
-  ap RepoAudit::Report.new(repo: repo).run
-  puts
+results = RepoAudit::RepositoryHelper.list(user: 'ministryofjustice')[10..15].inject([]) do |list, repo|
+  list << RepoAudit::Report.new(repo: repo).run
 end
+
+puts results.to_json

--- a/bin/transform_csv.rb
+++ b/bin/transform_csv.rb
@@ -1,0 +1,11 @@
+#!/usr/bin/env ruby
+
+require_relative '../lib/repo-audit'
+
+puts RepoAudit::CsvReport.new(
+  config: [
+    ["Repository", "repo"],
+    ["License Check", "license_check"]
+  ],
+  data: JSON.parse(STDIN.read)
+).to_csv

--- a/lib/repo-audit.rb
+++ b/lib/repo-audit.rb
@@ -1,5 +1,6 @@
 require 'bundler/setup'
 require 'awesome_print'
+require 'csv'
 require 'github_api'
 require 'open-uri'
 require 'pp'
@@ -17,7 +18,7 @@ require_relative './repo-audit/file_fetcher'
 require_relative './repo-audit/license_checker'
 require_relative './repo-audit/repository_helper'
 require_relative './repo-audit/report'
-
+require_relative './repo-audit/csv_report'
 require_relative './repo-audit/checks/base_check'
 
 # This will take care of requiring all the checks, without having to add

--- a/lib/repo-audit.rb
+++ b/lib/repo-audit.rb
@@ -1,9 +1,9 @@
 require 'bundler/setup'
-require 'github_api'
 require 'awesome_print'
+require 'github_api'
+require 'open-uri'
 require 'pp'
 require 'pry-byebug'
-require 'open-uri'
 
 module RepoAudit
 end

--- a/lib/repo-audit/csv_report.rb
+++ b/lib/repo-audit/csv_report.rb
@@ -1,0 +1,59 @@
+module RepoAudit
+
+  # Transform the parsed JSON output of the bin/analyse.rb script
+  # into CSV data.
+  class CsvReport
+
+    # Takes:: A single hash with keys;
+    #
+    # * data:: A list of hashes where each hash is the RepoAudit::Report output from a
+    #          single github repository
+    #
+    # * config:: A list of 2-element arrays, where the first element is the column heading
+    #            and the second is the name of the key in the *data* hash whose value will
+    #            populate the column. Provided the key name is unique, it is not necessary
+    #            to specify it's 'path' in the hash. e.g. the key name _baz_ will find the
+    #            key in the hash;
+    #
+    #                { foo: { bar: { baz: { result: 'passed' } } } }
+    #
+    #            If the value of _key_ is a hash with a key of _result_ (as per the example
+    #            above), then the value of result is returned, otherwise the value of _key_
+    #            is returned.
+    #
+    def initialize(params)
+      @config = params.fetch(:config)
+      @data = params.fetch(:data)
+    end
+
+    def to_csv
+      [header, lines].join
+    end
+
+    private
+
+    def header
+      @config.map {|t| t[0]}.to_csv
+    end
+
+    def lines
+      @data.inject([]) do |arr, entry|
+        res = Hashie::Mash.new(entry)
+        res.extend Hashie::Extensions::DeepFind
+
+        arr << line(res)
+      end
+    end
+
+    def line(entry)
+      @config.map {|t| t[1]}
+      .inject([]) {|arr, key| arr << value(entry, key)}
+      .to_csv
+    end
+
+    def value(entry, key)
+      val = entry.deep_find(key)
+      val.respond_to?(:result) ? val.result : val
+    end
+  end
+end

--- a/spec/csv_report_spec.rb
+++ b/spec/csv_report_spec.rb
@@ -1,0 +1,35 @@
+require_relative 'spec_helper'
+
+describe RepoAudit::CsvReport do
+  let(:entry) {
+    {
+      "repo" => "repository name",
+      "results" => {
+        "license_check" => {
+          "result" => "failed"
+        }
+      }
+    }
+  }
+
+  let(:data) { [entry] }
+
+  let(:config) {
+    [
+      ["Repository", "repo"],
+      ["License Check", "license_check"]
+    ]
+  }
+
+  let(:transformer) { described_class.new(data: data, config: config) }
+
+  it "transforms to CSV" do
+    csv = <<~CSV
+    Repository,License Check
+    repository name,failed
+    CSV
+    expect(transformer.to_csv).to eq(csv)
+  end
+
+end
+


### PR DESCRIPTION
This PR adds a CsvReport class and an example script. The output of
bin/analyse.rb can be piped into the script, and the output will be a CSV
containing whichever columns were specified in the config property when the
CsvReport was instantiated.