### PR TITLE
Implement a last_commit_check

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ the rules or not.
 ## Usage
 
 * `bundle install`
-* [Create a Github OAuth token](https://github.com/settings/tokens/new) with at least the following scopes enabled: _read:org, read:repo_hook, read:user, repo:status_
+* [Create a Github OAuth token](https://github.com/settings/tokens/new) with at least the following scopes enabled: _repo, user_
 * `export GH_TOKEN=[your OAuth token]`
 
 To analyse all repositories in the ministryofjustice organisation:

--- a/lib/repo-audit/checks/last_commit_check.rb
+++ b/lib/repo-audit/checks/last_commit_check.rb
@@ -1,0 +1,6 @@
+module RepoAudit::Checks
+  class LastCommitCheck < BaseCheck
+    register_check :last_commit_check
+  end
+end
+

--- a/lib/repo-audit/checks/last_commit_check.rb
+++ b/lib/repo-audit/checks/last_commit_check.rb
@@ -1,6 +1,18 @@
 module RepoAudit::Checks
   class LastCommitCheck < BaseCheck
     register_check :last_commit_check
+
+    def run(repo)
+      commit = RepoAudit::RepositoryHelper.last_commit(user: repo.owner.login, name: repo.name)
+      author = commit.fetch("commit").fetch("author")
+      result(
+        timestamp: DateTime.parse(author.fetch("date")),
+        author: {
+          name: author.fetch("name"),
+          email: author.fetch("email")
+        }
+      )
+    end
   end
 end
 

--- a/lib/repo-audit/repository_helper.rb
+++ b/lib/repo-audit/repository_helper.rb
@@ -9,6 +9,15 @@ module RepoAudit
         github_client.repos.list(user: user)
       end
 
+      def last_commit(user:, name:)
+        github_client(auto_pagination: false)
+          .repos
+          .commits
+          .list(user, name)
+          .to_a
+          .first
+      end
+
       private
 
       # auto_pagination: false - only look at 30 repos. Switch to true to look at

--- a/lib/repo-audit/repository_helper.rb
+++ b/lib/repo-audit/repository_helper.rb
@@ -11,10 +11,10 @@ module RepoAudit
 
       private
 
-      def github_client
-        # auto_pagination: false - only look at 30 repos. Switch to true to look at
-        # everything. Be warned, it's a bit slow.
-        Github::Client.new(auto_pagination: false, oauth_token: ENV.fetch('GH_TOKEN'))
+      # auto_pagination: false - only look at 30 repos. Switch to true to look at
+      # everything. Be warned, it's a bit slow.
+      def github_client(auto_pagination: false)
+        Github::Client.new(auto_pagination: auto_pagination, oauth_token: ENV.fetch('GH_TOKEN'))
       end
     end
   end

--- a/repo-audit.yml
+++ b/repo-audit.yml
@@ -17,3 +17,7 @@ checks:
       filename: Dangerfile
       content_matchers:
         - ministryofjustice/danger
+
+  - type: :last_commit_check
+    metadata:
+      description: 'Timestamp and author of the last commit'

--- a/spec/checks/last_commit_check_spec.rb
+++ b/spec/checks/last_commit_check_spec.rb
@@ -1,0 +1,9 @@
+require_relative '../spec_helper'
+
+describe RepoAudit::Checks::LastCommitCheck do
+  let(:metadata)  { {description: 'check description', style_guide_url: 'www.example.com'} }
+  let(:arguments) { {} }
+  subject(:check) { described_class.new(metadata, arguments) }
+
+  it_behaves_like 'a Check', name: :last_commit_check
+end

--- a/spec/checks/last_commit_check_spec.rb
+++ b/spec/checks/last_commit_check_spec.rb
@@ -6,4 +6,41 @@ describe RepoAudit::Checks::LastCommitCheck do
   subject(:check) { described_class.new(metadata, arguments) }
 
   it_behaves_like 'a Check', name: :last_commit_check
+
+  context '#run' do
+    let(:repository) { double('Repository', name: 'my-repo') }
+    let(:date) { "2017-07-20T09:39:39Z" }
+    let(:commit_hash) {
+      {
+        "commit" => {
+          "author" => {
+            "name" => "Jesus Laiz",
+            "email" => "zheileman@users.noreply.github.com",
+            "date" => date
+          }
+        }
+      }
+    }
+
+    before do
+      allow(repository).to receive_message_chain(:owner, login: 'ministryofjustice')
+      allow(RepoAudit::RepositoryHelper).to receive(:last_commit).and_return(commit_hash)
+    end
+
+    it 'returns the expected result' do
+      expect(check.run(repository)).to \
+        eq('RepoAudit::Checks::LastCommitCheck' => {
+          result: {
+            timestamp: DateTime.parse(date),
+            author: {
+              name: "Jesus Laiz",
+              email: "zheileman@users.noreply.github.com"
+            }
+          },
+          description: 'check description'
+      })
+    end
+
+  end
+
 end

--- a/spec/repository_helper_spec.rb
+++ b/spec/repository_helper_spec.rb
@@ -10,6 +10,18 @@ describe RepoAudit::RepositoryHelper do
     ).and_return(github_client)
   end
 
+  context '.last_commit' do
+    let(:commits) { double(Array) }
+
+    it 'fetches the last commit using the Github client' do
+      expect(Github::Client).to receive(:new).with(hash_including(auto_pagination: false))
+      expect(github_client).to receive_message_chain(:repos, :commits, list: commits).with('org', 'repo')
+      expect(commits).to receive_message_chain(:to_a, :first)
+
+      described_class.last_commit(user: 'org', name: 'repo')
+    end
+  end
+
   context '.find' do
     it 'raises an exception when required arguments are not supplied' do
       expect { described_class.find(foo: 'bar') }.to raise_error(ArgumentError)


### PR DESCRIPTION
This commit outputs the timestamp, author name and author email of the last
commit to the repo being analysed. For now, I've done this as a nested hash
of `results`, but this can easily be changed, if we decide to handle value
'checks' differently.
References #38 