### PR TITLE
Add check for presence of at least one file

### DIFF
--- a/lib/repo-audit/checks/at_least_one_file_check.rb
+++ b/lib/repo-audit/checks/at_least_one_file_check.rb
@@ -1,0 +1,22 @@
+module RepoAudit::Checks
+  class AtLeastOneFileCheck < BaseCheck
+    include RepoAudit::RepositoryContent
+
+    register_check :at_least_one_file_check
+
+    attr_accessor :filenames
+
+    def run(repo)
+      at_least_one_file_exists?(repo) ? success : failure
+    end
+
+    private
+
+    def at_least_one_file_exists?(repo)
+      filenames.detect do |filename|
+        url = file_url(repo, filename)
+        RepoAudit::FileRequestHelper.exists?(url)
+      end
+    end
+  end
+end

--- a/lib/repo-audit/checks/at_least_one_file_check.rb
+++ b/lib/repo-audit/checks/at_least_one_file_check.rb
@@ -14,7 +14,7 @@ module RepoAudit::Checks
 
     def at_least_one_file_exists?(repo)
       filenames.detect do |filename|
-        url = file_url(repo, filename)
+        url = repository_file_url(repo, filename)
         RepoAudit::FileRequestHelper.exists?(url)
       end
     end

--- a/lib/repo-audit/checks/file_content_check.rb
+++ b/lib/repo-audit/checks/file_content_check.rb
@@ -4,10 +4,11 @@ module RepoAudit::Checks
 
     register_check :file_content_check
 
+    attr_accessor :filename
     attr_accessor :content_matchers
 
     def run(repo)
-      url = file_url(repo)
+      url = file_url(repo, filename)
       file_content_matches?(url) ? success : failure
     end
 

--- a/lib/repo-audit/checks/file_content_check.rb
+++ b/lib/repo-audit/checks/file_content_check.rb
@@ -14,7 +14,7 @@ module RepoAudit::Checks
     private
 
     def file_content_matches?(repo)
-      url = file_url(repo, filename)
+      url = repository_file_url(repo, filename)
       file_content = RepoAudit::FileRequestHelper.fetch(url)
 
       content_matchers.all? do |regex|

--- a/lib/repo-audit/checks/file_content_check.rb
+++ b/lib/repo-audit/checks/file_content_check.rb
@@ -8,13 +8,13 @@ module RepoAudit::Checks
     attr_accessor :content_matchers
 
     def run(repo)
-      url = file_url(repo, filename)
-      file_content_matches?(url) ? success : failure
+      file_content_matches?(repo) ? success : failure
     end
 
     private
 
-    def file_content_matches?(url)
+    def file_content_matches?(repo)
+      url = file_url(repo, filename)
       file_content = RepoAudit::FileRequestHelper.fetch(url)
 
       content_matchers.all? do |regex|

--- a/lib/repo-audit/checks/required_file_check.rb
+++ b/lib/repo-audit/checks/required_file_check.rb
@@ -13,7 +13,7 @@ module RepoAudit::Checks
     private
 
     def file_exists?(repo)
-      url = file_url(repo, filename)
+      url = repository_file_url(repo, filename)
       RepoAudit::FileRequestHelper.exists?(url)
     end
   end

--- a/lib/repo-audit/checks/required_file_check.rb
+++ b/lib/repo-audit/checks/required_file_check.rb
@@ -4,8 +4,10 @@ module RepoAudit::Checks
 
     register_check :required_file_check
 
+    attr_accessor :filename
+
     def run(repo)
-      url = file_url(repo)
+      url = file_url(repo, filename)
       file_exists?(url) ? success : failure
     end
 

--- a/lib/repo-audit/checks/required_file_check.rb
+++ b/lib/repo-audit/checks/required_file_check.rb
@@ -7,13 +7,13 @@ module RepoAudit::Checks
     attr_accessor :filename
 
     def run(repo)
-      url = file_url(repo, filename)
-      file_exists?(url) ? success : failure
+      file_exists?(repo) ? success : failure
     end
 
     private
 
-    def file_exists?(url)
+    def file_exists?(repo)
+      url = file_url(repo, filename)
       RepoAudit::FileRequestHelper.exists?(url)
     end
   end

--- a/lib/repo-audit/repository_content.rb
+++ b/lib/repo-audit/repository_content.rb
@@ -2,11 +2,9 @@ module RepoAudit
   module RepositoryContent
     URL_PATTERN = 'https://raw.githubusercontent.com/%{repo_full_name}/master/%{filename}'.freeze
 
-    attr_accessor :filename
-
     private
 
-    def file_url(repo)
+    def file_url(repo, filename)
       format(URL_PATTERN, repo_full_name: repo.full_name, filename: filename)
     end
   end

--- a/lib/repo-audit/repository_content.rb
+++ b/lib/repo-audit/repository_content.rb
@@ -4,7 +4,7 @@ module RepoAudit
 
     private
 
-    def file_url(repo, filename)
+    def repository_file_url(repo, filename)
       format(URL_PATTERN, repo_full_name: repo.full_name, filename: filename)
     end
   end

--- a/repo-audit.yml
+++ b/repo-audit.yml
@@ -17,3 +17,11 @@ checks:
       filename: Dangerfile
       content_matchers:
         - ministryofjustice/danger
+
+  - type: :at_least_one_file_check
+    metadata:
+      description: 'Repository uses at least one of these CI: Travis or Circle'
+    arguments:
+      filenames:
+        - .travis.yml
+        - circle.yml

--- a/spec/checks/at_least_one_file_check_spec.rb
+++ b/spec/checks/at_least_one_file_check_spec.rb
@@ -1,0 +1,59 @@
+require_relative '../spec_helper'
+
+describe RepoAudit::Checks::AtLeastOneFileCheck do
+  let(:metadata)  { {description: 'check description', style_guide_url: 'www.example.com'} }
+  let(:arguments) { {filenames: %w[file1.txt file2.txt]} }
+
+  subject { described_class.new(metadata, arguments) }
+
+  it_behaves_like 'a Check', name: :at_least_one_file_check
+
+  context '#run' do
+    let(:repository) { double('Repository', full_name: 'org/repo-name') }
+
+    context 'for a success result in the first file' do
+      it 'returns the expected result' do
+        expect(RepoAudit::FileRequestHelper).to receive(:exists?).with(
+          'https://raw.githubusercontent.com/org/repo-name/master/file1.txt'
+        ).and_return(true)
+
+        expect(RepoAudit::FileRequestHelper).not_to receive(:exists?).with(
+          'https://raw.githubusercontent.com/org/repo-name/master/file2.txt'
+        )
+
+        expect(subject).to receive(:success)
+        subject.run(repository)
+      end
+    end
+
+    context 'for a failure result in the first file and success result in the second file' do
+      it 'returns the expected result' do
+        expect(RepoAudit::FileRequestHelper).to receive(:exists?).with(
+          'https://raw.githubusercontent.com/org/repo-name/master/file1.txt'
+        ).and_return(false)
+
+        expect(RepoAudit::FileRequestHelper).to receive(:exists?).with(
+          'https://raw.githubusercontent.com/org/repo-name/master/file2.txt'
+        ).and_return(true)
+
+        expect(subject).to receive(:success)
+        subject.run(repository)
+      end
+    end
+
+    context 'for a failure result' do
+      it 'returns the expected result' do
+        expect(RepoAudit::FileRequestHelper).to receive(:exists?).with(
+          'https://raw.githubusercontent.com/org/repo-name/master/file1.txt'
+        ).and_return(false)
+
+        expect(RepoAudit::FileRequestHelper).to receive(:exists?).with(
+          'https://raw.githubusercontent.com/org/repo-name/master/file2.txt'
+        ).and_return(false)
+
+        expect(subject).to receive(:failure)
+        subject.run(repository)
+      end
+    end
+  end
+end


### PR DESCRIPTION
There are some checks that require checking for the presence of at least one file from a given list of filenames.
Specifically this PR ensures the repository is using one of our supported CI files: Travis or Circle.