### PR TITLE
Update check shared tests to cope with nil args

### DIFF
--- a/lib/repo-audit/checks/base_check.rb
+++ b/lib/repo-audit/checks/base_check.rb
@@ -3,7 +3,7 @@ module RepoAudit::Checks
     attr_reader :description
     attr_reader :style_guide_url
 
-    def initialize(metadata, arguments)
+    def initialize(metadata, arguments = nil)
       @description = metadata.fetch(:description)
       @style_guide_url = metadata.fetch(:style_guide_url, 'n/a')
 

--- a/lib/repo-audit/checks_factory.rb
+++ b/lib/repo-audit/checks_factory.rb
@@ -3,7 +3,7 @@ module RepoAudit
     class CheckNotFoundError < RuntimeError; end
 
     class << self
-      def build(type, metadata, arguments = nil)
+      def build(type, metadata, arguments)
         fetch(type).new(metadata, arguments)
       end
 

--- a/spec/checks/checks_shared_examples.rb
+++ b/spec/checks/checks_shared_examples.rb
@@ -8,8 +8,8 @@ RSpec.shared_examples 'a Check' do |options|
   end
 
   describe '.new' do
-    it 'requires the metadata and the arguments' do
-      expect { described_class.new }.to raise_error(ArgumentError, /given 0, expected 2/)
+    it 'requires the metadata and optionally the arguments' do
+      expect { described_class.new }.to raise_error(ArgumentError, /given 0, expected 1..2/)
     end
 
     context 'configures the check with the metadata' do
@@ -42,21 +42,11 @@ RSpec.shared_examples 'a Check' do |options|
       end
     end
 
-    context 'configures the check with the arguments' do
-      context 'when expected arguments are provided' do
-        it 'sets the attribute values' do
-          expect(
-            arguments.values
-          ).to eq(arguments.keys.map { |attr| subject.public_send(attr) })
-        end
-      end
+    context 'when unexpected arguments are provided' do
+      let(:arguments) { {whatever: 'hello'} }
 
-      context 'when unexpected arguments are provided' do
-        let(:arguments) { {whatever: 'hello'} }
-
-        it 'raises an exception' do
-          expect { subject.name_matcher }.to raise_error(NoMethodError, /whatever/)
-        end
+      it 'raises an exception' do
+        expect { subject.whatever }.to raise_error(NoMethodError, /whatever/)
       end
     end
   end

--- a/spec/checks/last_commit_check_spec.rb
+++ b/spec/checks/last_commit_check_spec.rb
@@ -2,8 +2,7 @@ require_relative '../spec_helper'
 
 describe RepoAudit::Checks::LastCommitCheck do
   let(:metadata)  { {description: 'check description', style_guide_url: 'www.example.com'} }
-  let(:arguments) { {} }
-  subject(:check) { described_class.new(metadata, arguments) }
+  subject(:check) { described_class.new(metadata) }
 
   it_behaves_like 'a Check', name: :last_commit_check
 

--- a/spec/checks_factory_spec.rb
+++ b/spec/checks_factory_spec.rb
@@ -45,7 +45,7 @@ describe RepoAudit::ChecksFactory do
 
     it 'it retrieves the check from the store' do
       expect(subject).to receive(:fetch).with(:test_check).and_call_original
-      subject.build(:test_check, {})
+      subject.build(:test_check, nil, nil)
     end
 
     it 'instantiate a check, given their type' do


### PR DESCRIPTION
Until now we only had `checks` with mandatory arguments, so the shared
examples were created assuming this was always the case, but with the
introduction of our first check without arguments (8bdec44) we need to
adapt the shared examples to cope with this.

After a bit of thinking, I realized we don't need explicit tests for
the arguments, as those are needed as part of the check `#run` and thus
are implicitly tested, in order to support this `#run` method.

There is however a minor change to allow any check to be instantiated
only with the metadata, so tests can be less verbose.

Fixes #40