### PR TITLE
Remove the '_check' suffix from the config

### DIFF
--- a/lib/repo-audit/checks/at_least_one_file_check.rb
+++ b/lib/repo-audit/checks/at_least_one_file_check.rb
@@ -2,7 +2,7 @@ module RepoAudit::Checks
   class AtLeastOneFileCheck < BaseCheck
     include RepoAudit::RepositoryContent
 
-    register_check :at_least_one_file_check
+    register_check :at_least_one_file
 
     attr_accessor :filenames
 

--- a/lib/repo-audit/checks/example_check.rb
+++ b/lib/repo-audit/checks/example_check.rb
@@ -1,7 +1,7 @@
 module RepoAudit::Checks
   class ExampleCheck < BaseCheck
     # This method will register in the factory this check Class
-    register_check :example_check
+    register_check :example
 
     # Checks can have configuration accessors needed for their task to be accomplished
     attr_accessor :name_matcher

--- a/lib/repo-audit/checks/file_content_check.rb
+++ b/lib/repo-audit/checks/file_content_check.rb
@@ -2,7 +2,7 @@ module RepoAudit::Checks
   class FileContentCheck < BaseCheck
     include RepoAudit::RepositoryContent
 
-    register_check :file_content_check
+    register_check :file_content
 
     attr_accessor :filename
     attr_accessor :content_matchers

--- a/lib/repo-audit/checks/last_commit_check.rb
+++ b/lib/repo-audit/checks/last_commit_check.rb
@@ -1,6 +1,6 @@
 module RepoAudit::Checks
   class LastCommitCheck < BaseCheck
-    register_check :last_commit_check
+    register_check :last_commit
 
     def run(repo)
       commit = RepoAudit::RepositoryHelper.last_commit(user: repo.owner.login, name: repo.name)

--- a/lib/repo-audit/checks/required_file_check.rb
+++ b/lib/repo-audit/checks/required_file_check.rb
@@ -2,7 +2,7 @@ module RepoAudit::Checks
   class RequiredFileCheck < BaseCheck
     include RepoAudit::RepositoryContent
 
-    register_check :required_file_check
+    register_check :required_file
 
     attr_accessor :filename
 

--- a/repo-audit.yml
+++ b/repo-audit.yml
@@ -1,5 +1,5 @@
 checks:
-  - type: :file_content_check
+  - type: :file_content
     metadata:
       description: 'LICENSE file has the expected content'
       style_guide_url: 'http://example.com/#file-license-content'
@@ -9,7 +9,7 @@ checks:
         - MIT License
         - Copyright \(c\) [\d-]+ Crown copyright \(Ministry of Justice\)
 
-  - type: :file_content_check
+  - type: :file_content
     metadata:
       description: 'Dangerfile file has the expected content'
       style_guide_url: 'http://example.com/#file-dangerfile-content'
@@ -18,7 +18,7 @@ checks:
       content_matchers:
         - ministryofjustice/danger
 
-  - type: :at_least_one_file_check
+  - type: :at_least_one_file
     metadata:
       description: 'Repository uses at least one of these CI: Travis or Circle'
     arguments:
@@ -26,6 +26,6 @@ checks:
         - .travis.yml
         - circle.yml
 
-  - type: :last_commit_check
+  - type: :last_commit
     metadata:
       description: 'Timestamp and author of the last commit'

--- a/spec/checks/at_least_one_file_check_spec.rb
+++ b/spec/checks/at_least_one_file_check_spec.rb
@@ -6,7 +6,7 @@ describe RepoAudit::Checks::AtLeastOneFileCheck do
 
   subject { described_class.new(metadata, arguments) }
 
-  it_behaves_like 'a Check', name: :at_least_one_file_check
+  it_behaves_like 'a Check', name: :at_least_one_file
 
   context '#run' do
     let(:repository) { double('Repository', full_name: 'org/repo-name') }

--- a/spec/checks/example_check_spec.rb
+++ b/spec/checks/example_check_spec.rb
@@ -6,7 +6,7 @@ describe RepoAudit::Checks::ExampleCheck do
 
   subject { described_class.new(metadata, arguments) }
 
-  it_behaves_like 'a Check', name: :example_check
+  it_behaves_like 'a Check', name: :example
 
   context '#run' do
     let(:repository) { double('Repository', name: repo_name) }

--- a/spec/checks/file_content_check_spec.rb
+++ b/spec/checks/file_content_check_spec.rb
@@ -7,7 +7,7 @@ describe RepoAudit::Checks::FileContentCheck do
 
   subject { described_class.new(metadata, arguments) }
 
-  it_behaves_like 'a Check', name: :file_content_check
+  it_behaves_like 'a Check', name: :file_content
 
   context '#run' do
     let(:repository) { double('Repository', full_name: 'org/repo-name') }

--- a/spec/checks/last_commit_check_spec.rb
+++ b/spec/checks/last_commit_check_spec.rb
@@ -4,7 +4,7 @@ describe RepoAudit::Checks::LastCommitCheck do
   let(:metadata)  { {description: 'check description', style_guide_url: 'www.example.com'} }
   subject(:check) { described_class.new(metadata) }
 
-  it_behaves_like 'a Check', name: :last_commit_check
+  it_behaves_like 'a Check', name: :last_commit
 
   context '#run' do
     let(:repository) { double('Repository', name: 'my-repo') }

--- a/spec/checks/required_file_check_spec.rb
+++ b/spec/checks/required_file_check_spec.rb
@@ -6,7 +6,7 @@ describe RepoAudit::Checks::RequiredFileCheck do
 
   subject { described_class.new(metadata, arguments) }
 
-  it_behaves_like 'a Check', name: :required_file_check
+  it_behaves_like 'a Check', name: :required_file
 
   context '#run' do
     let(:repository) { double('Repository', full_name: 'org/repo-name') }


### PR DESCRIPTION
Inside the 'checks' block of the config, we don't
need to keep calling everything xxx_check

Fixes #41