### PR TITLE
Bugfix: Allow args to be a subclass of Hash

### DIFF
--- a/lib/repo-audit/checks/base_check.rb
+++ b/lib/repo-audit/checks/base_check.rb
@@ -27,7 +27,7 @@ module RepoAudit::Checks
     private
 
     def set_attributes(args)
-      return unless args.instance_of?(Hash)
+      return unless args.is_a?(Hash)
       args.each { |k, v| public_send("#{k}=", v) }
     end
 

--- a/spec/checks/base_check_spec.rb
+++ b/spec/checks/base_check_spec.rb
@@ -12,8 +12,8 @@ describe RepoAudit::Checks::BaseCheck do
     end
   end
 
-  context 'with arguments hash' do
-    let(:arguments) { { foo: 'bar' } }
+  context 'with arguments' do
+    let(:arguments) { Hashie::Mash.new(foo: 'bar') }
 
     class Wibble < RepoAudit::Checks::BaseCheck
       attr_accessor :foo


### PR DESCRIPTION
Mutant prefers 'instance_of?' to 'is_a?', if the tests pass with
either. But, the BaseCheck test for arguments was sending a Hash,
when in normal use, it's a Hashie::Mash. So, although the tests
were passing, the code was wrong.
This commit fixes that bug.