### PR TITLE
Allow the config loader class to be injected

### DIFF
--- a/lib/repo-audit/configuration.rb
+++ b/lib/repo-audit/configuration.rb
@@ -1,7 +1,7 @@
 module RepoAudit
   class Configuration < SimpleDelegator
-    def self.load(file)
-      new Hashie::Mash.load(file)
+    def self.load(file, loader_class = Hashie::Mash)
+      new loader_class.load(file)
     end
   end
 end

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -2,17 +2,18 @@ require_relative 'spec_helper'
 
 describe RepoAudit::Configuration do
   let(:config_file) { 'spec/fixtures/example-config.yml' }
+  let(:loader_class) { class_double('Loader') }
 
   subject { described_class.load(config_file) }
 
   describe '.load' do
-    it 'reads the file and returns a Configuration instance' do
+    it 'returns a Configuration instance' do
       expect(subject).to be_an_instance_of(described_class)
     end
 
-    it 'uses Hashie to load the file' do
-      expect(Hashie::Mash).to receive(:load).with(config_file)
-      described_class.load(config_file)
+    it 'uses the loader class to read the file' do
+      expect(loader_class).to receive(:load).with(config_file)
+      described_class.load(config_file, loader_class)
     end
   end
 


### PR DESCRIPTION
This enables the coupling between the implementation and the specs
to be removed (i.e. we no longer need to specify that Hashie::Mash
is used to load the config.