### PR TITLE
Add a script to simplify running mutant tests

### DIFF
--- a/bin/mutant.rb
+++ b/bin/mutant.rb
@@ -1,0 +1,13 @@
+#!/usr/bin/env ruby
+
+# Pass a match expression as an optional argument to only run mutant
+# on classes that match. Example: `bin/mutant.rb RepoAudit::ChecksFactory`
+
+flags = '--use rspec --fail-fast'.freeze
+klasses = Array(ARGV[0] || 'RepoAudit*').freeze
+
+klasses.each do |klass|
+  unless system("bundle exec mutant #{flags} #{klass}")
+    raise 'Mutation testing failed'
+  end
+end


### PR DESCRIPTION
The amount of classes are growing and so the time mutant takes to run.
This script will make it easier to run mutant against the whole project,
or passing a single class to run mutant quickly only on that class.