### PR TITLE
Add check for ruby and rails versions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,5 @@
 source 'https://rubygems.org'
+ruby '2.3.3'
 
 gem 'github_api'
 gem 'hashie'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -161,5 +161,8 @@ DEPENDENCIES
   pry-byebug
   rspec
 
+RUBY VERSION
+   ruby 2.3.3p222
+
 BUNDLED WITH
    1.14.3

--- a/lib/repo-audit.rb
+++ b/lib/repo-audit.rb
@@ -14,6 +14,7 @@ require_relative './repo-audit/file_request_helper'
 require_relative './repo-audit/repository_helper'
 require_relative './repo-audit/repository_content'
 require_relative './repo-audit/report'
+require_relative './repo-audit/version_matcher'
 
 require_relative './repo-audit/checks/base_check'
 

--- a/lib/repo-audit.rb
+++ b/lib/repo-audit.rb
@@ -8,6 +8,7 @@ module RepoAudit
 end
 
 require_relative './repo-audit/configuration'
+require_relative './repo-audit/constants'
 require_relative './repo-audit/checks_factory'
 require_relative './repo-audit/checks_collection'
 require_relative './repo-audit/file_request_helper'

--- a/lib/repo-audit/checks/version_check.rb
+++ b/lib/repo-audit/checks/version_check.rb
@@ -15,9 +15,7 @@ module RepoAudit
       private
 
       def match_version?(repo)
-        file_matchers.detect do |matcher_hash|
-          filename, regex = matcher_hash.flatten
-
+        file_matchers.detect do |filename, regex|
           url = repository_file_url(repo, filename)
           file_content = FileRequestHelper.fetch(url)
 

--- a/lib/repo-audit/checks/version_check.rb
+++ b/lib/repo-audit/checks/version_check.rb
@@ -1,0 +1,32 @@
+module RepoAudit
+  module Checks
+    class VersionCheck < BaseCheck
+      include RepoAudit::RepositoryContent
+
+      register_check :version
+
+      attr_accessor :version
+      attr_accessor :file_matchers
+
+      def run(repo)
+        match_version?(repo) ? success : failure
+      end
+
+      private
+
+      def match_version?(repo)
+        file_matchers.detect do |matcher_hash|
+          filename, regex = matcher_hash.flatten
+
+          url = repository_file_url(repo, filename)
+          file_content = FileRequestHelper.fetch(url)
+
+          VersionMatcher.new(
+            content: file_content,
+            version_regex: regex
+          ).satisfies?(version)
+        end
+      end
+    end
+  end
+end

--- a/lib/repo-audit/constants.rb
+++ b/lib/repo-audit/constants.rb
@@ -1,0 +1,11 @@
+module RepoAudit::Constants
+  RUBY_VERSION_FILES = [
+    ['Gemfile',       '^ruby \'(?<version>\S+)\''],
+    ['.ruby-version', '^(?<version>\S+)$'],
+    ['.travis.yml',   '^rvm: (?<version>\S+)$']
+  ].freeze
+
+  RAILS_VERSION_FILES = [
+    ['Gemfile.lock',  '^\s+rails \((?<version>\S+)\)$']
+  ].freeze
+end

--- a/lib/repo-audit/version_matcher.rb
+++ b/lib/repo-audit/version_matcher.rb
@@ -1,0 +1,22 @@
+module RepoAudit
+  class VersionMatcher
+    attr_reader :content
+    attr_reader :version_regex
+
+    def initialize(content:, version_regex:)
+      @content = content
+      @version_regex = version_regex
+    end
+
+    def satisfies?(version)
+      Gem::Requirement.create(version).satisfied_by?(matched_version)
+    end
+
+    private
+
+    def matched_version
+      match = Regexp.new(version_regex).match(content) || {}
+      Gem::Version.new(match[:version])
+    end
+  end
+end

--- a/repo-audit.yml
+++ b/repo-audit.yml
@@ -2,7 +2,6 @@ checks:
   - type: :file_content
     metadata:
       description: 'LICENSE file has the expected content'
-      style_guide_url: 'http://example.com/#file-license-content'
     arguments:
       filename: LICENSE
       content_matchers:
@@ -12,7 +11,6 @@ checks:
   - type: :file_content
     metadata:
       description: 'Dangerfile file has the expected content'
-      style_guide_url: 'http://example.com/#file-dangerfile-content'
     arguments:
       filename: Dangerfile
       content_matchers:
@@ -25,6 +23,24 @@ checks:
       filenames:
         - .travis.yml
         - circle.yml
+
+  - type: :version
+    metadata:
+      description: 'If a ruby repository, version must be ~> 2.2'
+    arguments:
+      version: '~> 2.2'
+      file_matchers:
+        - Gemfile: ^ruby '(?<version>\S+)'$
+        - .ruby-version: ^(?<version>\S+)$
+        - .travis.yml: '^rvm: (?<version>\S+)$'
+
+  - type: :version
+    metadata:
+      description: 'If a rails repository, Rails version must be >= 4.2'
+    arguments:
+      version: '>= 4.2'
+      file_matchers:
+        - Gemfile.lock: ^\s+rails \((?<version>\S+)\)$
 
   - type: :last_commit
     metadata:

--- a/repo-audit.yml
+++ b/repo-audit.yml
@@ -29,18 +29,14 @@ checks:
       description: 'If a ruby repository, version must be ~> 2.2'
     arguments:
       version: '~> 2.2'
-      file_matchers:
-        - Gemfile: ^ruby '(?<version>\S+)'$
-        - .ruby-version: ^(?<version>\S+)$
-        - .travis.yml: '^rvm: (?<version>\S+)$'
+      file_matchers: <%= RepoAudit::Constants::RUBY_VERSION_FILES %>
 
   - type: :version
     metadata:
       description: 'If a rails repository, Rails version must be >= 4.2'
     arguments:
       version: '>= 4.2'
-      file_matchers:
-        - Gemfile.lock: ^\s+rails \((?<version>\S+)\)$
+      file_matchers: <%= RepoAudit::Constants::RAILS_VERSION_FILES %>
 
   - type: :last_commit
     metadata:

--- a/spec/checks/version_check_spec.rb
+++ b/spec/checks/version_check_spec.rb
@@ -2,7 +2,7 @@ require_relative '../spec_helper'
 
 describe RepoAudit::Checks::VersionCheck do
   let(:metadata)  { {description: 'check description', style_guide_url: 'www.example.com'} }
-  let(:arguments) { {version: '~> 2.2', file_matchers: [{'Gemfile' => "^ruby '(?<version>\.*)'$"}]} }
+  let(:arguments) { {version: '~> 2.2', file_matchers: [['Gemfile', '^ruby \'(?<version>\S+)\'']]} }
 
   subject { described_class.new(metadata, arguments) }
 

--- a/spec/checks/version_check_spec.rb
+++ b/spec/checks/version_check_spec.rb
@@ -1,0 +1,49 @@
+require_relative '../spec_helper'
+
+describe RepoAudit::Checks::VersionCheck do
+  let(:metadata)  { {description: 'check description', style_guide_url: 'www.example.com'} }
+  let(:arguments) { {version: '~> 2.2', file_matchers: [{'Gemfile' => "^ruby '(?<version>\.*)'$"}]} }
+
+  subject { described_class.new(metadata, arguments) }
+
+  it_behaves_like 'a Check', name: :version
+
+  context '#run' do
+    let(:repository) { double('Repository', full_name: 'org/repo-name') }
+
+    before do
+      allow(RepoAudit::FileRequestHelper).to receive(:fetch).with(
+        'https://raw.githubusercontent.com/org/repo-name/master/Gemfile'
+      ).and_return(file_content)
+    end
+
+    context 'for a success result' do
+      let(:file_content) { "ruby '2.3.3'" }
+
+      it 'invokes the `success` result' do
+        expect(subject).to receive(:success)
+        subject.run(repository)
+      end
+    end
+
+    context 'for a failure result' do
+      context 'the version found in the file content does not satisfy the required version' do
+        let(:file_content) { "ruby '2.1.1'" }
+
+        it 'invokes the `failure` result' do
+          expect(subject).to receive(:failure)
+          subject.run(repository)
+        end
+      end
+
+      context 'no version was found in the file content' do
+        let(:file_content) { 'Lorem ipsum dolor sit amet, MIT License.' }
+
+        it 'invokes the `failure` result' do
+          expect(subject).to receive(:failure)
+          subject.run(repository)
+        end
+      end
+    end
+  end
+end

--- a/spec/version_matcher_spec.rb
+++ b/spec/version_matcher_spec.rb
@@ -1,0 +1,51 @@
+require_relative 'spec_helper'
+
+describe RepoAudit::VersionMatcher do
+  let(:content) { 'content' }
+  let(:version_regex) { 'version_regex' }
+
+  subject { described_class.new(content: content, version_regex: version_regex) }
+
+  describe '.new' do
+    it 'receives the content and the version regex' do
+      expect { subject }.not_to raise_error
+    end
+
+    it 'raise an error if wrong arguments' do
+      expect { described_class.new }.to raise_error(/missing keywords: content, version_regex/)
+    end
+  end
+
+  describe '#satisfies?' do
+    context 'for successful results' do
+      let(:content) { '1.2.3' }
+      let(:version_regex) { '^(?<version>\S+)$' }
+
+      it { expect(subject.satisfies?('1.2.3')).to eq(true) }
+      it { expect(subject.satisfies?('> 1.2')).to eq(true) }
+      it { expect(subject.satisfies?('>= 1.2')).to eq(true) }
+      it { expect(subject.satisfies?('< 2.0')).to eq(true) }
+      it { expect(subject.satisfies?('<= 1.2.3')).to eq(true) }
+      it { expect(subject.satisfies?('~> 1.2.2')).to eq(true) }
+      it { expect(subject.satisfies?('~> 1.0')).to eq(true) }
+    end
+
+    context 'for unsuccessful results' do
+      let(:content) { '1.2.3' }
+      let(:version_regex) { '^(?<version>\S+)$' }
+
+      it { expect(subject.satisfies?('1.2.4')).to eq(false) }
+      it { expect(subject.satisfies?('> 1.3')).to eq(false) }
+      it { expect(subject.satisfies?('>= 1.3')).to eq(false) }
+      it { expect(subject.satisfies?('< 1.2.3')).to eq(false) }
+      it { expect(subject.satisfies?('<= 1.2.2')).to eq(false) }
+      it { expect(subject.satisfies?('~> 1.3')).to eq(false) }
+      it { expect(subject.satisfies?('~> 0.9')).to eq(false) }
+
+      context 'when no match was found in content' do
+        let(:content) { 'lorem ipsum' }
+        it { expect(subject.satisfies?('1.2.3')).to eq(false) }
+      end
+    end
+  end
+end


### PR DESCRIPTION
Please note, as per last commit message (6fa9a52), as it stands right now the check will result in a failure for non-Ruby or non-Rails repositories, so next step is to create a mechanism to bypass this check (and potentially others in the future) when not needed (i.e. not a Rails repo, so no need to check for Rails version).

In order to do this I kind of have an idea. We can have `pre-requisites` to be met in order for a check to run or not. A pre-requisite could be, for example, **uses_rails** and might encapsulate a little check in itself (i.e. could look for the existence of the `Gemfile`).

I didn't want to do this work as part of this PR as will potentially affect the BaseCheck and maybe Factory and Collection, and change quite a few tests. Also, I wanted to gather feedback first.

Of course, we can also have a **very pragmatic, interim solution**, which is to return a result of `not applicable` or something like that if none of the files we are looking for are found. After all, the pre-requisite for Rails would be to look for the gem in the Gemfile.lock, so it is implicit this file must exists in order to be able to check for such a gem version.

If we feel like not wanting to merge this PR without first having these `pre-requisites` or whatever mechanism we decide so we don't get false-negatives for non-ruby/rails repos, we can still comment out the version checks in the config file before merging it.